### PR TITLE
Fix Flask server to serve frontend and add tests

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -41,3 +41,46 @@ jobs:
       with:
         name: compiled-backend
         path: dist/main.exe
+
+  frontend-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: |
+        cd frontend
+        npm install
+
+    - name: Run frontend tests
+      run: |
+        cd frontend
+        npm test -- --watchAll=false
+
+  backend-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r backend/requirements.txt
+
+    - name: Run backend tests
+      run: |
+        pytest

--- a/backend/main.py
+++ b/backend/main.py
@@ -320,7 +320,7 @@ def riemann_prediction(time_points, values, future_points=5):
         return None
 
 # Flask app for frontend integration
-app = Flask(__name__)
+app = Flask(__name__, static_folder='../frontend/build', static_url_path='/')
 CORS(app)
 
 @app.route('/api/analyze-matches', methods=['POST'])
@@ -403,7 +403,11 @@ def download_executable():
     """Serve the compiled executable file to the frontend"""
     return send_from_directory('dist', 'main.exe')
 
+@app.route('/')
+def serve_frontend():
+    return send_from_directory(app.static_folder, 'index.html')
+
 if __name__ == "__main__":
     # Ensure plots directory exists
     os.makedirs('plots', exist_ok=True)
-    app.run(debug=True, port=5000)
+    app.run(debug=True, port=5000, host='0.0.0.0')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 scipy
 openai
 pyinstaller
+pytest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "recharts": "^2.14.1"
+    "recharts": "^2.14.1",
+    "@testing-library/jest-dom": "^5.16.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders main page correctly', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/League of Legends Match Analyzer/i);
+  expect(headerElement).toBeInTheDocument();
+});
+
+test('renders analyze button', () => {
+  render(<App />);
+  const buttonElement = screen.getByText(/Analyze Matches/i);
+  expect(buttonElement).toBeInTheDocument();
 });


### PR DESCRIPTION
Add route to serve frontend and update GitHub Actions for testing.

* **backend/main.py**
  - Add a new route `/` to serve the frontend build files.
  - Import `send_from_directory` from `flask` to serve static files.
  - Modify the `app.run` call to set `host='0.0.0.0'` to allow external access.

* **frontend/src/App.test.js**
  - Add a test to check if the main page renders correctly.
  - Add a test to check if the analyze button is present.

* **.github/workflows/compile.yml**
  - Add a new job to run the frontend tests.
  - Add a new job to run the backend tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Nulper/Leagueanalyzer/pull/4?shareId=3ef55165-d3a6-4b30-adb8-6c610541c089).