### PR TITLE
Serve frontend with Python

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -412,9 +412,6 @@ def analyze_matches():
             save_data_to_csv(match_data_list)
             save_plot_images("match_data.csv")
             
-            logger.info(f"Compiling executable")
-            os.system("pyinstaller --onefile backend/main.py --add-data 'frontend/build;frontend/build'")
-            
             logger.info(f"Analysis completed successfully for {name}#{tag}")
             return jsonify({
                 'matches': match_data_list,
@@ -455,6 +452,10 @@ def serve_frontend():
     else:
         logger.error(f"Frontend build not found at {static_folder_path}")
         return "Frontend build not found. Please run 'npm run build' in the 'frontend' directory.", 404
+
+@app.route('/frontend/<path:filename>')
+def serve_frontend_files(filename):
+    return send_from_directory(os.path.join(application_path, 'frontend', 'build'), filename)
 
 if __name__ == "__main__":
     logger.info("Starting application")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,14 +13,16 @@
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
     "recharts": "^2.14.1",
-    "web-vitals": "^4.2.4"
+    "web-vitals": "^4.2.4",
+    "serve": "^14.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "build-frontend": "npm run build"
+    "build-frontend": "npm run build",
+    "serve-build": "serve -s build"
   },
   "eslintConfig": {
     "extends": [

--- a/start_servers.bat
+++ b/start_servers.bat
@@ -7,8 +7,8 @@ start cmd /k "cd backend && venv\Scripts\activate && python main.py"
 :: Wait for 3 seconds to let backend initialize
 timeout /t 3 /nobreak
 
-:: Start the frontend server
-start cmd /k "cd frontend && npm start"
+:: Start the frontend server using the new script
+start cmd /k "cd frontend && npm run serve-build"
 
 echo Both servers are starting...
 echo Frontend: http://localhost:3000


### PR DESCRIPTION
Add functionality to serve the frontend build files using Flask in the backend and update scripts to start the frontend server.

* **backend/main.py**
  - Add a new route to serve the frontend build files using Flask's `send_from_directory` function.
  - Modify the `analyze_matches` function to remove the `os.system` call to `pyinstaller`.

* **frontend/package.json**
  - Add a new script to start the frontend server using `serve -s build`.

* **start_servers.bat**
  - Modify the script to use the new frontend server script instead of `npm start`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Nulper/Leagueanalyzer/pull/9?shareId=6ed1cfea-2d56-4f55-ba25-3a2547303e2b).