### PR TITLE
Fix JSON serialization error in analyze_matches

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -62,8 +62,8 @@ def get_openai_response(prompt):
             max_tokens=150
         )
         logger.info("Successfully received OpenAI response")
-        logger.info(f"Response: {response.choices[0].message}")
-        return response.choices[0].message
+        logger.info(f"Response: {response.choices[0].message.content}")
+        return response.choices[0].message.content
     except Exception as e:
         logger.error(f"Error in OpenAI response: {str(e)}")
         raise


### PR DESCRIPTION
Modify `get_openai_response` to return the content of the message instead of the entire message object.

* Log the content of the message instead of the entire message object to avoid JSON serialization errors.
* Return `response.choices[0].message.content` instead of `response.choices[0].message`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Nulper/Leagueanalyzer/pull/11?shareId=15fe693a-574f-4ee7-8a41-d0bf9c6e6fb4).